### PR TITLE
feat: 운동 세션 중복 방지 및 페이지 이탈 시 운동 종료 로직 추가

### DIFF
--- a/src/pages/Exercise/ExercisePage.tsx
+++ b/src/pages/Exercise/ExercisePage.tsx
@@ -34,6 +34,8 @@ interface Exercise {
 interface SessionRecord {
   record_id: number;
   exercise_id: number;
+  duration: number;
+  ended_at?: string | null;
 }
 
 interface PregnancyMeResponse {
@@ -84,15 +86,39 @@ export default function ExercisePage() {
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const lastVibrationAtRef = useRef<number>(0);
 
-  const [currentIndex, setCurrentIndex] = useState(0);
+  //  백엔드 데이터에서 이미 완료된(ended_at이 있는) 운동 ID 뽑아내기
+  const initialEndedIds =
+    session?.records
+      ?.filter((r: any) => r.ended_at !== null)
+      ?.map((r: any) => Number(r.exercise_id)) || [];
+
+  // 아직 완료되지 않은 첫 번째 운동의 인덱스 찾기
+  const firstUnfinishedIndex = exercises.findIndex(
+    (ex) => !initialEndedIds.includes(Number(ex.id)),
+  );
+  const startingIndex = firstUnfinishedIndex !== -1 ? firstUnfinishedIndex : 0;
+
+  // 하다가 멈춘 운동이 있다면, 그 운동의 저장된 진행 시간(초) 가져오기
+  const startingRecord = session?.records?.find(
+    (r: any) => Number(r.exercise_id) === Number(exercises[startingIndex]?.id),
+  );
+  const initialElapsed = startingRecord?.duration || 0;
+
+  // 상태 초기화에 적용
+  const [currentIndex, setCurrentIndex] = useState(startingIndex);
   const [playState, setPlayState] = useState<PlayState>("idle");
   const [duration, setDuration] = useState(0);
-  const [elapsed, setElapsed] = useState(0);
+  const [elapsed, setElapsed] = useState(initialElapsed); // 0초 대신 저장된 시간부터!
   const [ytReady, setYtReady] = useState(false);
-  const [endedExerciseIds, setEndedExerciseIds] = useState<number[]>([]);
+  const [endedExerciseIds, setEndedExerciseIds] =
+    useState<number[]>(initialEndedIds);
+
   const [stopModal, setStopModal] = useState(false);
   const [leaveModal, setLeaveModal] = useState(false);
-  const [switchModal, setSwitchModal] = useState<{ open: boolean; targetIndex: number }>({ open: false, targetIndex: 0 });
+  const [switchModal, setSwitchModal] = useState<{
+    open: boolean;
+    targetIndex: number;
+  }>({ open: false, targetIndex: 0 });
   const [maxAllowedBpm, setMaxAllowedBpm] = useState<number | null>(null);
 
   const [showHRModal, setShowHRModal] = useState(false);
@@ -105,7 +131,7 @@ export default function ExercisePage() {
         );
         if (!hasToday) setShowHRModal(true);
       })
-      .catch(() => { }); // 실패 시 모달 띄우지 않음 (막지 않음)
+      .catch(() => {}); // 실패 시 모달 띄우지 않음 (막지 않음)
   }, []);
 
   const current = exercises[currentIndex];
@@ -115,7 +141,10 @@ export default function ExercisePage() {
       ?.record_id ?? null;
 
   useEffect(() => {
-    if (window.YT?.Player) { setYtReady(true); return; }
+    if (window.YT?.Player) {
+      setYtReady(true);
+      return;
+    }
     const existing = document.querySelector<HTMLScriptElement>(
       'script[src="https://www.youtube.com/iframe_api"]',
     );
@@ -127,7 +156,9 @@ export default function ExercisePage() {
     window.onYouTubeIframeAPIReady = () => setYtReady(true);
   }, []);
 
-  useEffect(() => { resetSessionHeartRates(); }, [resetSessionHeartRates]);
+  useEffect(() => {
+    resetSessionHeartRates();
+  }, [resetSessionHeartRates]);
 
   useEffect(() => {
     getJson<PregnancyMeResponse>("/pregnancy/me")
@@ -141,12 +172,25 @@ export default function ExercisePage() {
   useEffect(() => {
     if (!current || !ytReady || !playerElRef.current || !isConnected) return;
 
+    const currentRecord = session?.records?.find(
+      (r) => Number(r.exercise_id) === Number(current.id),
+    );
+    const startSeconds = currentRecord?.duration || 0;
+
     playerRef.current?.destroy();
-    setPlayState("idle"); setElapsed(0); setDuration(0);
+    setPlayState("idle");
+    setElapsed(startSeconds); // 무조건 0이 아니라, 저장된 시간부터 타이머가 돌게 세팅
+    setDuration(0);
 
     playerRef.current = new window.YT.Player(playerElRef.current, {
       videoId: toVideoId(current.videoUrl),
-      playerVars: { controls: 0, rel: 0, modestbranding: 1, autoplay: 0 },
+      playerVars: {
+        controls: 0,
+        rel: 0,
+        modestbranding: 1,
+        autoplay: 0,
+        start: startSeconds,
+      },
       events: {
         onReady: (e: { target: YTPlayer }) => {
           setDuration(e.target.getDuration());
@@ -174,7 +218,9 @@ export default function ExercisePage() {
     } else {
       if (timerRef.current) clearInterval(timerRef.current);
     }
-    return () => { if (timerRef.current) clearInterval(timerRef.current); };
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
   }, [playState]);
 
   useEffect(() => {
@@ -186,18 +232,38 @@ export default function ExercisePage() {
     vibrate(true).catch((e) => console.error("[vibration] 실패:", e));
   }, [currentBpm, maxAllowedBpm, playState, vibrate]);
 
+  // [이탈 방어] 탭 닫기, 새로고침, 뒤로 가기, 네비게이션 바 이동 감지 및 중단 처리
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
       if (!session?.session_id || allowNavigationRef.current) return;
       e.preventDefault();
+      e.returnValue = "";
     };
+
     window.addEventListener("beforeunload", handleBeforeUnload);
-    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
-  }, [session?.session_id]);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+
+      if (session?.session_id && !allowNavigationRef.current) {
+        console.log(
+          "🚨 페이지 이탈 감지: 운동을 '일시정지' 상태로 보존합니다.",
+        );
+
+        // 세션 전체 중단(abort)이 아니라, 현재 진행 중이던 운동(record)만 일시정지
+        const activeRecordId = getActiveRecordId();
+        if (activeRecordId) {
+          postJson("/exercise/record/pause", {
+            record_id: activeRecordId,
+          }).catch(() => {});
+        }
+      }
+    };
+  }, [session?.session_id, current.id]); // current.id(현재 운동) 의존성 추가
 
   const getActiveRecordId = () => getRecordId(current.id);
 
-  // ✅ Fix 1: boolean 반환 + 중복 API 호출 제거 + API 성공 후 상태 업데이트
+  // boolean 반환 + 중복 API 호출 제거 + API 성공 후 상태 업데이트
   const handleRecordEnd = async (
     exerciseId: number,
     onDone: () => void,
@@ -217,7 +283,9 @@ export default function ExercisePage() {
       });
       // ✅ API 성공 확인 후 로컬 상태 정리
       setEndedExerciseIds((prev) =>
-        prev.includes(Number(exerciseId)) ? prev : [...prev, Number(exerciseId)],
+        prev.includes(Number(exerciseId))
+          ? prev
+          : [...prev, Number(exerciseId)],
       );
       onDone();
       return true;
@@ -268,10 +336,16 @@ export default function ExercisePage() {
     const ended = new Set(endedExerciseIds);
     if (justEndedId) ended.add(justEndedId);
     for (let i = currentIndex + 1; i < exercises.length; i++) {
-      if (!ended.has(Number(exercises[i].id))) { setCurrentIndex(i); return; }
+      if (!ended.has(Number(exercises[i].id))) {
+        setCurrentIndex(i);
+        return;
+      }
     }
     for (let i = 0; i < currentIndex; i++) {
-      if (!ended.has(Number(exercises[i].id))) { setCurrentIndex(i); return; }
+      if (!ended.has(Number(exercises[i].id))) {
+        setCurrentIndex(i);
+        return;
+      }
     }
     finishAll();
   };
@@ -285,7 +359,11 @@ export default function ExercisePage() {
   const finishAll = () => {
     allowNavigationRef.current = true;
     navigate("/report", {
-      state: { exercises, sessionId: session?.session_id, heartRates: getSessionHeartRates() },
+      state: {
+        exercises,
+        sessionId: session?.session_id,
+        heartRates: getSessionHeartRates(),
+      },
     });
   };
 
@@ -354,7 +432,9 @@ export default function ExercisePage() {
       playerRef.current?.pauseVideo();
       setPlayState("idle");
 
-      const success = await handleRecordEnd(current.id, () => setCurrentIndex(target));
+      const success = await handleRecordEnd(current.id, () =>
+        setCurrentIndex(target),
+      );
       if (success) {
         stopExerciseMode();
       } else {
@@ -391,7 +471,10 @@ export default function ExercisePage() {
       <RestingHeartRateModal
         isOpen={showHRModal}
         onClose={() => setShowHRModal(false)}
-        onSaved={() => { setHasTodayHR(true); setShowHRModal(false); }}
+        onSaved={() => {
+          setHasTodayHR(true);
+          setShowHRModal(false);
+        }}
       />
 
       {!showHRModal && (
@@ -417,12 +500,16 @@ export default function ExercisePage() {
             <StatCard>
               <StatLabel>남은 시간</StatLabel>
               <StatValue>
-                {duration > 0 ? formatTime(Math.max(duration - elapsed, 0)) : "--:--"}
+                {duration > 0
+                  ? formatTime(Math.max(duration - elapsed, 0))
+                  : "--:--"}
               </StatValue>
             </StatCard>
             <StatCard>
               <StatLabel>❤️ 심박수</StatLabel>
-              <StatValue style={{ fontSize: isDisplayNumeric ? "30px" : "15px" }}>
+              <StatValue
+                style={{ fontSize: isDisplayNumeric ? "30px" : "15px" }}
+              >
                 {displayBpm}
                 {isDisplayNumeric && <StatUnit>bpm</StatUnit>}
               </StatValue>
@@ -436,7 +523,9 @@ export default function ExercisePage() {
 
           <ExerciseInfo>
             <ExTitle>{current.title}</ExTitle>
-            <ExMeta>{currentIndex + 1}/{exercises.length}</ExMeta>
+            <ExMeta>
+              {currentIndex + 1}/{exercises.length}
+            </ExMeta>
           </ExerciseInfo>
 
           <ControlRow>
@@ -447,7 +536,9 @@ export default function ExercisePage() {
             )}
             {playState === "playing" && (
               <>
-                <ActionButton $variant="outline" onClick={handlePause}>일시정지</ActionButton>
+                <ActionButton $variant="outline" onClick={handlePause}>
+                  일시정지
+                </ActionButton>
                 <ActionButton $variant="danger" onClick={handleCurrentEnd}>
                   {hasNextAvailableExercise ? "다음 운동" : "운동 종료"}
                 </ActionButton>
@@ -489,7 +580,11 @@ export default function ExercisePage() {
           </EmergencyStop>
 
           {/* ── 모달들 ── */}
-          <Modal isOpen={stopModal} onClose={() => setStopModal(false)} showCloseButton={false}>
+          <Modal
+            isOpen={stopModal}
+            onClose={() => setStopModal(false)}
+            showCloseButton={false}
+          >
             <ModalBody>
               <ModalEmoji>⚠️</ModalEmoji>
               <ModalTitle>운동을 종료할까요?</ModalTitle>
@@ -497,8 +592,12 @@ export default function ExercisePage() {
                 운동이 아직 남아있어요.{"\n"}지금 종료하면 리포트로 이동합니다.
               </ModalDesc>
               <ModalButtons>
-                <ModalOutlineBtn onClick={() => setStopModal(false)}>계속할게요</ModalOutlineBtn>
-                <ModalFillBtn onClick={handleStopConfirm}>종료하기</ModalFillBtn>
+                <ModalOutlineBtn onClick={() => setStopModal(false)}>
+                  계속할게요
+                </ModalOutlineBtn>
+                <ModalFillBtn onClick={handleStopConfirm}>
+                  종료하기
+                </ModalFillBtn>
               </ModalButtons>
             </ModalBody>
           </Modal>
@@ -512,11 +611,16 @@ export default function ExercisePage() {
               <ModalTitle>다른 운동으로 이동할까요?</ModalTitle>
               <ModalDesc>
                 현재 <strong>{current.title}</strong>을 종료하고{"\n"}
-                <strong>{exercises[switchModal.targetIndex]?.title}</strong>으로 이동합니다.{"\n"}
+                <strong>{exercises[switchModal.targetIndex]?.title}</strong>으로
+                이동합니다.{"\n"}
                 종료된 운동은 다시 실행할 수 없어요.
               </ModalDesc>
               <ModalButtons>
-                <ModalOutlineBtn onClick={() => setSwitchModal({ open: false, targetIndex: 0 })}>
+                <ModalOutlineBtn
+                  onClick={() =>
+                    setSwitchModal({ open: false, targetIndex: 0 })
+                  }
+                >
                   돌아가기
                 </ModalOutlineBtn>
                 <ModalFillBtn onClick={handleSwitchConfirm}>
@@ -526,16 +630,25 @@ export default function ExercisePage() {
             </ModalBody>
           </Modal>
 
-          <Modal isOpen={leaveModal} onClose={() => setLeaveModal(false)} showCloseButton={false}>
+          <Modal
+            isOpen={leaveModal}
+            onClose={() => setLeaveModal(false)}
+            showCloseButton={false}
+          >
             <ModalBody>
               <ModalEmoji>⚠️</ModalEmoji>
               <ModalTitle>운동을 종료하고 나가시겠어요?</ModalTitle>
               <ModalDesc>
-                현재 운동 기록이 중단 처리됩니다.{"\n"}이동 후에는 이 운동 세션을 이어서 진행할 수 없어요.
+                현재 운동 기록이 중단 처리됩니다.{"\n"}이동 후에는 이 운동
+                세션을 이어서 진행할 수 없어요.
               </ModalDesc>
               <ModalButtons>
-                <ModalOutlineBtn onClick={() => setLeaveModal(false)}>계속 운동하기</ModalOutlineBtn>
-                <ModalFillBtn onClick={handleLeaveConfirm}>종료하고 나가기</ModalFillBtn>
+                <ModalOutlineBtn onClick={() => setLeaveModal(false)}>
+                  계속 운동하기
+                </ModalOutlineBtn>
+                <ModalFillBtn onClick={handleLeaveConfirm}>
+                  종료하고 나가기
+                </ModalFillBtn>
               </ModalButtons>
             </ModalBody>
           </Modal>
@@ -547,96 +660,199 @@ export default function ExercisePage() {
 
 // ── Styled ───────────────────────────────────────────────────
 const Container = styled.div`
-  display: flex; flex-direction: column;
-  height: 100%; overflow-y: auto; padding: 24px 16px 120px;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+  padding: 24px 16px 120px;
 `;
 const Header = styled.div`
-  display: flex; align-items: center; justify-content: space-between; margin-bottom: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
 `;
 const PageTitle = styled.h1`
   ${({ theme }) => theme.typography.heading2}
-  color: ${({ theme }) => theme.colors.text.primary}; margin: 0;
+  color: ${({ theme }) => theme.colors.text.primary};
+  margin: 0;
 `;
 const VideoBox = styled.div`
-  width: 100%; aspect-ratio: 16/9;
+  width: 100%;
+  aspect-ratio: 16/9;
   border-radius: ${({ theme }) => theme.borderRadius.lg};
-  overflow: hidden; margin-bottom: ${({ theme }) => theme.spacing.md}; flex-shrink: 0;
+  overflow: hidden;
+  margin-bottom: ${({ theme }) => theme.spacing.md};
+  flex-shrink: 0;
 `;
 const StatsRow = styled.div`
-  display: flex; gap: ${({ theme }) => theme.spacing.md}; margin-bottom: ${({ theme }) => theme.spacing.md};
+  display: flex;
+  gap: ${({ theme }) => theme.spacing.md};
+  margin-bottom: ${({ theme }) => theme.spacing.md};
 `;
 const StatCard = styled.div`
-  flex: 1; background: ${({ theme }) => theme.colors.white};
+  flex: 1;
+  background: ${({ theme }) => theme.colors.white};
   border: 1px solid ${({ theme }) => theme.colors.sub};
   border-radius: ${({ theme }) => theme.borderRadius.lg};
   padding: ${({ theme }) => theme.spacing.md};
-  display: flex; flex-direction: column; gap: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 `;
 const StatLabel = styled.p`
-  ${({ theme }) => theme.typography.caption} color: ${({ theme }) => theme.colors.subtext}; margin: 0;
+  ${({ theme }) => theme.typography.caption} color: ${({ theme }) =>
+    theme.colors.subtext};
+  margin: 0;
 `;
 const StatValue = styled.p`
-  font-size: 30px; font-weight: 700; color: ${({ theme }) => theme.colors.point}; margin: 0; line-height: 1.2;
+  font-size: 30px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.point};
+  margin: 0;
+  line-height: 1.2;
 `;
 const StatUnit = styled.span`
-  ${({ theme }) => theme.typography.body2} color: ${({ theme }) => theme.colors.subtext}; margin-left: 4px;
+  ${({ theme }) => theme.typography.body2} color: ${({ theme }) =>
+    theme.colors.subtext};
+  margin-left: 4px;
 `;
-const ExerciseInfo = styled.div`margin-bottom: ${({ theme }) => theme.spacing.md};`;
+const ExerciseInfo = styled.div`
+  margin-bottom: ${({ theme }) => theme.spacing.md};
+`;
 const ExTitle = styled.h2`
-  ${({ theme }) => theme.typography.heading2} color: ${({ theme }) => theme.colors.text.primary}; margin: 0 0 4px;
+  ${({ theme }) => theme.typography.heading2} color: ${({ theme }) =>
+    theme.colors.text.primary};
+  margin: 0 0 4px;
 `;
 const ExMeta = styled.p`
-  ${({ theme }) => theme.typography.body2} color: ${({ theme }) => theme.colors.subtext}; margin: 0;
+  ${({ theme }) => theme.typography.body2} color: ${({ theme }) =>
+    theme.colors.subtext};
+  margin: 0;
 `;
 const ControlRow = styled.div`
-  display: flex; gap: ${({ theme }) => theme.spacing.sm}; margin-bottom: ${({ theme }) => theme.spacing.lg};
+  display: flex;
+  gap: ${({ theme }) => theme.spacing.sm};
+  margin-bottom: ${({ theme }) => theme.spacing.lg};
 `;
 const ActionButton = styled.button<{ $variant?: "outline" | "danger" }>`
-  flex: 1; height: 60px;
+  flex: 1;
+  height: 60px;
   border-radius: ${({ theme }) => theme.borderRadius.md};
-  ${({ theme }) => theme.typography.button} cursor: pointer; transition: all 0.2s;
+  ${({ theme }) => theme.typography.button} cursor: pointer;
+  transition: all 0.2s;
   ${({ $variant, theme }) => {
     switch ($variant) {
-      case "outline": return `background:transparent;border:1.5px solid ${theme.colors.point};color:${theme.colors.point};&:hover{background:${theme.colors.light};}`;
-      case "danger": return `background:${theme.colors.point};border:none;color:${theme.colors.white};&:hover{filter:brightness(0.92);}`;
-      default: return `background:${theme.colors.light};border:1px solid ${theme.colors.point};color:${theme.colors.point};&:hover{background:${theme.colors.sub};}`;
+      case "outline":
+        return `background:transparent;border:1.5px solid ${theme.colors.point};color:${theme.colors.point};&:hover{background:${theme.colors.light};}`;
+      case "danger":
+        return `background:${theme.colors.point};border:none;color:${theme.colors.white};&:hover{filter:brightness(0.92);}`;
+      default:
+        return `background:${theme.colors.light};border:1px solid ${theme.colors.point};color:${theme.colors.point};&:hover{background:${theme.colors.sub};}`;
     }
   }}
-  &:disabled { opacity: 0.55; cursor: not-allowed; }
-  &:active { transform: scale(0.98); }
+  &:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+  &:active {
+    transform: scale(0.98);
+  }
 `;
-const ListSection = styled.div`display:flex;flex-direction:column;gap:${({ theme }) => theme.spacing.sm};`;
+const ListSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
 const ListTitle = styled.h3`
-  ${({ theme }) => theme.typography.body2} color:${({ theme }) => theme.colors.subtext};
-  margin:0 0 ${({ theme }) => theme.spacing.sm};
+  ${({ theme }) => theme.typography.body2} color:${({ theme }) =>
+    theme.colors.subtext};
+  margin: 0 0 ${({ theme }) => theme.spacing.sm};
 `;
 const EmergencyStop = styled.button`
-  width:100%;margin-top:${({ theme }) => theme.spacing.lg};padding:18px 16px 14px;
-  background:#fff5f5;border:2px solid #e53935;border-radius:${({ theme }) => theme.borderRadius.lg};
-  color:#e53935;cursor:pointer;display:flex;flex-direction:column;align-items:center;gap:6px;
-  ${({ theme }) => theme.typography.caption}font-weight:500;transition:all 0.2s;
-  &:hover{background:#ffebee;}&:active{transform:scale(0.98);}
+  width: 100%;
+  margin-top: ${({ theme }) => theme.spacing.lg};
+  padding: 18px 16px 14px;
+  background: #fff5f5;
+  border: 2px solid #e53935;
+  border-radius: ${({ theme }) => theme.borderRadius.lg};
+  color: #e53935;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  ${({ theme }) => theme.typography.caption}font-weight:500;
+  transition: all 0.2s;
+  &:hover {
+    background: #ffebee;
+  }
+  &:active {
+    transform: scale(0.98);
+  }
 `;
-const EmergencyStopLabel = styled.span`font-size:17px;font-weight:700;color:#e53935;letter-spacing:-0.3px;`;
-const ModalBody = styled.div`display:flex;flex-direction:column;align-items:center;gap:${({ theme }) => theme.spacing.sm};text-align:center;`;
-const ModalEmoji = styled.span`font-size:40px;`;
-const ModalTitle = styled.p`${({ theme }) => theme.typography.heading3}color:${({ theme }) => theme.colors.text.primary};margin:0;`;
-const ModalDesc = styled.p`${({ theme }) => theme.typography.body2}color:${({ theme }) => theme.colors.subtext};margin:0;white-space:pre-line;`;
-const ModalButtons = styled.div`display:flex;gap:${({ theme }) => theme.spacing.sm};width:100%;margin-top:${({ theme }) => theme.spacing.sm};`;
+const EmergencyStopLabel = styled.span`
+  font-size: 17px;
+  font-weight: 700;
+  color: #e53935;
+  letter-spacing: -0.3px;
+`;
+const ModalBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.sm};
+  text-align: center;
+`;
+const ModalEmoji = styled.span`
+  font-size: 40px;
+`;
+const ModalTitle = styled.p`
+  ${({ theme }) => theme.typography.heading3}color:${({ theme }) =>
+    theme.colors.text.primary};
+  margin: 0;
+`;
+const ModalDesc = styled.p`
+  ${({ theme }) => theme.typography.body2}color:${({ theme }) =>
+    theme.colors.subtext};
+  margin: 0;
+  white-space: pre-line;
+`;
+const ModalButtons = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.spacing.sm};
+  width: 100%;
+  margin-top: ${({ theme }) => theme.spacing.sm};
+`;
 const ModalOutlineBtn = styled.button`
-  flex:1;padding:12px;border-radius:${({ theme }) => theme.borderRadius.md};
-  border:1.5px solid ${({ theme }) => theme.colors.point};background:transparent;
-  color:${({ theme }) => theme.colors.point};${({ theme }) => theme.typography.button}cursor:pointer;
-  &:hover{background:${({ theme }) => theme.colors.light};}
+  flex: 1;
+  padding: 12px;
+  border-radius: ${({ theme }) => theme.borderRadius.md};
+  border: 1.5px solid ${({ theme }) => theme.colors.point};
+  background: transparent;
+  color: ${({ theme }) => theme.colors.point};
+  ${({ theme }) => theme.typography.button}cursor:pointer;
+  &:hover {
+    background: ${({ theme }) => theme.colors.light};
+  }
 `;
 const ModalFillBtn = styled.button`
-  flex:1;padding:12px;border-radius:${({ theme }) => theme.borderRadius.md};border:none;
-  background:${({ theme }) => theme.colors.point};color:${({ theme }) => theme.colors.white};
-  ${({ theme }) => theme.typography.button}cursor:pointer;&:hover{filter:brightness(0.92);}
+  flex: 1;
+  padding: 12px;
+  border-radius: ${({ theme }) => theme.borderRadius.md};
+  border: none;
+  background: ${({ theme }) => theme.colors.point};
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.typography.button}cursor:pointer;
+  &:hover {
+    filter: brightness(0.92);
+  }
 `;
 const ExerciseItemWrapper = styled.div<{ $isEnded: boolean }>`
-  opacity:${({ $isEnded }) => ($isEnded ? 0.45 : 1)};
-  filter:${({ $isEnded }) => ($isEnded ? "grayscale(0.4)" : "none")};
-  pointer-events:${({ $isEnded }) => ($isEnded ? "none" : "auto")};
-  transition:opacity 0.2s ease,filter 0.2s ease;
+  opacity: ${({ $isEnded }) => ($isEnded ? 0.45 : 1)};
+  filter: ${({ $isEnded }) => ($isEnded ? "grayscale(0.4)" : "none")};
+  pointer-events: ${({ $isEnded }) => ($isEnded ? "none" : "auto")};
+  transition:
+    opacity 0.2s ease,
+    filter 0.2s ease;
 `;

--- a/src/pages/ExerciseList/ExerciseListPage.tsx
+++ b/src/pages/ExerciseList/ExerciseListPage.tsx
@@ -33,6 +33,15 @@ interface SessionResponse {
   }[];
 }
 
+interface CurrentSessionResponse {
+  session_id: number;
+  status: string;
+  records: {
+    record_id: number;
+    exercise_id: number;
+  }[];
+}
+
 interface RecommendResponse {
   recommend: ExerciseFromAPI[];
   caution: ExerciseFromAPI[];
@@ -78,12 +87,27 @@ const ExerciseListPage = () => {
   });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  const [ongoingSession, setOngoingSession] =
+    useState<CurrentSessionResponse | null>(null);
 
+  // 추천 운동 불러오기
   useEffect(() => {
     getJson<RecommendResponse>(`/recommend?t=${Date.now()}`)
       .then((json) => setData(json))
       .catch(() => setError(true))
       .finally(() => setLoading(false));
+  }, []);
+
+  // 진행 중인 세션 확인
+  useEffect(() => {
+    getJson<any>("/exercise/session/current")
+      .then((res) => {
+        // 백엔드에서 세션이 있으면 status가 'ONGOING'인 객체가 통째로 옵니다.
+        if (res && res.status === "ONGOING") {
+          setOngoingSession(res);
+        }
+      })
+      .catch(() => console.log("진행 중인 세션 없음"));
   }, []);
 
   const exercisesByTab: Record<TabKey, Exercise[]> = {
@@ -162,6 +186,29 @@ const ExerciseListPage = () => {
     }
   };
 
+  const handleResumeSession = () => {
+    if (!ongoingSession) return;
+
+    // 진행 중인 세션에 들어있던 운동 ID들을 뽑아서, 전체 추천 목록에서 상세 정보를 찾습니다.
+    const recordExerciseIds = ongoingSession.records.map(
+      (r: any) => r.exercise_id,
+    );
+    const sessionExercises = selectableExercises.filter((e) =>
+      recordExerciseIds.includes(Number(e.id)),
+    );
+
+    // 운동 페이지로 하던 세션 정보 그대로 넘어갑니다
+    navigate("/exercise", {
+      state: {
+        exercises: sessionExercises,
+        session: {
+          session_id: ongoingSession.session_id,
+          records: ongoingSession.records,
+        },
+      },
+    });
+  };
+
   return (
     <Container>
       <Title>오늘의 추천 운동</Title>
@@ -172,6 +219,21 @@ const ExerciseListPage = () => {
           등의 증상이 나타나면 즉시 중단하세요.
         </p>
       </Card>
+
+      {ongoingSession && (
+        <Card variant="info" icon="🏃‍♀️" title="진행 중인 운동이 있어요!">
+          <p style={{ marginBottom: "12px" }}>
+            이전에 하다가 멈춘 운동 세션이 있습니다. 이어서 하시겠어요?
+          </p>
+          <FillButton
+            disabled={false}
+            onClick={handleResumeSession}
+            style={{ padding: "8px 16px", width: "auto" }}
+          >
+            이어서 하기
+          </FillButton>
+        </Card>
+      )}
 
       {guideline && (
         <Card variant="info" icon="💡" title={guideline.title}>

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -46,6 +46,13 @@ interface HeartRateRecord {
   bpm: number;
 }
 
+interface WeeklyHeartRateResponse {
+  average: number | null;
+  max: number | null;
+  count: number;
+  records: HeartRateRecord[];
+}
+
 interface ExerciseHistoryResponse {
   sessions: {
     session_id: number;
@@ -53,7 +60,7 @@ interface ExerciseHistoryResponse {
   }[];
 }
 
-const DAYS = ["월", "화", "수", "목", "금", "토", "오늘"] as const;
+const WEEK_DAYS = ["월", "화", "수", "목", "금", "토", "일"];
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
@@ -90,9 +97,14 @@ export default function MyPage() {
   const navigate = useNavigate();
   const [user, setUser] = useState<UserInfo | null>(null);
   const [pregnancy, setPregnancy] = useState<PregnancyInfo | null>(null);
-  const [weeklyHR, setWeeklyHR] = useState<DailyHeartRate[]>(
-    DAYS.map((day) => ({ day, bpm: null })),
-  );
+  const [weeklyHR, setWeeklyHR] = useState<DailyHeartRate[]>(() => {
+    const today = new Date();
+    const dow = today.getDay() === 0 ? 6 : today.getDay() - 1;
+    return WEEK_DAYS.map((day, i) => ({
+      day: i === dow ? "오늘" : day,
+      bpm: null,
+    }));
+  });
   const [myPosts, setMyPosts] = useState<Post[]>([]);
   const [likedPosts, setLikedPosts] = useState<Post[]>([]);
   const [exerciseCount, setExerciseCount] = useState(0);
@@ -128,29 +140,28 @@ export default function MyPage() {
   // ── 주간 심박수: GET /heart-rate/weekly ───────────────────
   const loadHeartRate = useCallback(async () => {
     try {
-      const data = await getJson<HeartRateRecord[]>("/heart-rate/weekly");
+      const res = await getJson<WeeklyHeartRateResponse>("/heart-rate/weekly");
+      const data = res.records;
       const today = new Date();
 
-      // ✅ Fix: 이번 주 월요일을 기준점으로 고정한 뒤 i일씩 더함
-      // 기존 코드는 평일에 실행하면 i가 커질수록 미래 날짜가 되는 버그가 있었음
-      // 예) 월요일(dow=1)에 실행: i=1(화) → today+1(내일), i=5(토) → today+5(5일 후)
       const monday = new Date(today);
       const dow = today.getDay() === 0 ? 7 : today.getDay(); // 일요일=0 → 7로 변환
       monday.setDate(today.getDate() - dow + 1); // 이번 주 월요일
       monday.setHours(0, 0, 0, 0);
 
-      const mapped: DailyHeartRate[] = DAYS.map((day, i) => {
-        if (day === "오늘") {
-          const rec = data.find((r) => isToday(r.date));
-          return { day, bpm: rec?.bpm ?? null };
-        }
-        // i=0: 월, i=1: 화, ..., i=5: 토 → 항상 이번 주 과거/현재 날짜
+      const currentDowIndex = dow - 1; // 배열 인덱스용 (0: 월 ~ 6: 일)
+
+      const mapped: DailyHeartRate[] = WEEK_DAYS.map((dayName, i) => {
+        const displayDay = i === currentDowIndex ? "오늘" : dayName;
+
         const target = new Date(monday);
         target.setDate(monday.getDate() + i);
+
         const rec = data.find(
           (r) => new Date(r.date).toDateString() === target.toDateString(),
         );
-        return { day, bpm: rec?.bpm ?? null };
+
+        return { day: displayDay, bpm: rec?.bpm ?? null };
       });
 
       setWeeklyHR(mapped);

--- a/src/pages/Weight/WeightPage.tsx
+++ b/src/pages/Weight/WeightPage.tsx
@@ -253,7 +253,7 @@ export default function WeightPage() {
       {/* 이번 주 요약 카드 */}
       <SummaryCard>
         <SectionLabel>이번 주 요약</SectionLabel>
-        {currentWeek <= 113 && (
+        {currentWeek <= 13 && (
           <EarlyPregnancyTip>
             💡 <b>임신 1분기(초기) 안내</b>
             <br />이 시기에는 입덧과 식욕 저하 등으로 체중이 일시적으로


### PR DESCRIPTION
## 🎯 무엇을 만들었나요?
<!-- 이 PR이 어떤 작업인지 설명해주세요 -->

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요 -->
Closes #34

## 📱 변경 사항
- 
- 

## 🎨 스크린샷 / 영상
<!-- Before & After 비교 또는 동작 영상을 첨부해주세요 -->

### Before
<!-- 변경 전 -->

### After
<!-- 변경 후 -->

## ✅ 체크리스트
- [ ] 코드 리뷰 받았나요?
- [ ] 디자인 시안과 일치하나요?
- [ ] 테스트 완료했나요?
- [ ] 다른 기능에 영향 없나요?

## 💬 리뷰어에게
<!-- 특별히 봐줬으면 하는 부분이 있다면 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 중단된 운동 세션이 있으면 진행 중인 운동을 확인하고 이어서 할 수 있습니다.
  - 운동 세션을 재개할 때 이전 운동 위치와 경과 시간이 복원됩니다.
  - 세션 중 페이지를 떠날 경우 현재 진행 상황이 일시 저장됩니다.

- **개선 사항**
  - 운동 중지·전환·종료 과정의 안내와 동작이 더 안정적으로 개선되었습니다.
  - 주간 심박수 화면에서 요일과 ‘오늘’ 표시가 정확하게 제공됩니다.
  - 임신 14주 이후에는 초기 단계 안내가 표시되지 않습니다.
  - 운동 시간 정보가 없을 때 더욱 명확하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->